### PR TITLE
add wasm-lld build

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,6 +13,7 @@ cmake -G "Ninja" ^
     -DLLVM_INCLUDE_TESTS=OFF ^
     -DLLVM_INCLUDE_DOCS=OFF ^
     -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON ^
+    -DLLVM_TARGETS_TO_BUILD="Host;WebAssembly" \
     %SRC_DIR%
 
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,8 +14,8 @@ cmake \
   -DLLVM_OBJ_ROOT=${PREFIX} \
   -DLLVM_MAIN_INCLUDE_DIR=${PREFIX}/include \
   -DLLVM_CMAKE_PATH=${PREFIX}/lib/cmake/llvm \
+  -DLLVM_TARGETS_TO_BUILD="Host;WebAssembly" \
   ${CMAKE_ARGS} \
   ..
 
 make -j${CPU_COUNT}
-make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@ source:
     - cmake.diff
 
 build:
-  number: 0
-  skip: true  # [win and vc<14]
+  number: 1
 
 requirements:
   build:
@@ -29,6 +28,29 @@ requirements:
   run_constrained:
     - llvm =={{ version }}
 
+outputs:
+  - name: lld
+    script: install.sh  # [unix]
+  - name: wasm-lld
+    script: install.sh  # [unix]
+    requirements:
+      build:
+        - cmake >=3.4.3
+        - ninja    # [win]
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - make     # [not win]
+        - llvmdev =={{ version }}    # [build_platform != target_platform]
+      host:
+        - llvmdev =={{ version }}
+        - llvm
+        - {{ pin_subpackage('lld', exact=True) }}
+      run_constrained:
+        - llvm =={{ version }}
+    test:
+      commands:
+        - wasm-lld --version  # [linux]
+
 test:
   commands:
     - ld.lld --version  # [linux]
@@ -43,3 +65,4 @@ about:
 extra:
   recipe-maintainers:
     - isuruf
+    - wolfv


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

This enables wasm support in lld and, together with Binaryen and an upcoming emscripten recipe, will allow for webassembly compilation on conda-forge.

We could also put wasm-lld into the main output. Up to you, @isuruf.
